### PR TITLE
Adding delay to not fall in the stairs

### DIFF
--- a/MarieGuiGui/src/main.ino
+++ b/MarieGuiGui/src/main.ino
@@ -39,6 +39,10 @@ void setup_wifi() {
 void mqtt_callback(char* topic, byte* payload, unsigned int length) {
     if(length > 0){
         if(payload[0] == '0'){
+            if(relay_state == HIGH){
+              delay(120000);
+              // to make the light wait until people are down stairs after closing
+            }
             relay_state = LOW;
         }
         else if(payload[0] == '1'){


### PR DESCRIPTION
When we close the space, the stairs lights are turning off immediately. I added a 2 minutes delay to let the time for people to go down before it turns off (to avoid accidents).